### PR TITLE
feature / mobile hero / scale함수 사용하여 동일한 배율로 줄이기

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -168,6 +168,12 @@ footer .legal ul li:hover a {
   position: relative;
 }
 
+@media (max-width: 1000px) {
+  .inner {
+    max-width: 692px;
+  }
+}
+
 /* Btn */
 .btn {
   display: flex;
@@ -223,6 +229,18 @@ a.link::after {
   content: " >";
 }
 
+@media (max-width: 1000px) {
+  .links {
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+  }
+
+  a.link {
+    font-size: 17px;
+  }
+}
+
 /* Feature(Figures+Infos) */
 .feature {
   display: flex;
@@ -244,6 +262,16 @@ a.link::after {
   position: absolute;
   top: 0;
   left: 0;
+}
+
+@media (max-width: 740px) {
+  .figures {
+    display: flex;
+    justify-content: center;
+  }
+  .figures figure {
+    position: relative;
+  }
 }
 
 /* Infos */
@@ -1114,8 +1142,95 @@ main {
   font-weight: 500;
 }
 
-/* Power */
+@media (max-width: 1000px) {
+  .hero .inner {
+    padding-bottom: 80px;
+  }
 
+  .hero h1 {
+    width: 166px;
+    height: 68px;
+    transform: translate(448px, 165px);
+  }
+
+  .hero .figures {
+    height: 584px;
+    margin-bottom: 14px;
+  }
+  .hero figure {
+    transform: translate(70px, -24px);
+  }
+  .hero figure img {
+    width: 540px;
+  }
+  .hero figcaption .caption-camera {
+    /* scale을 사용하여 동일한 배수로 줄여야함. */
+    /* translate를 통해 새로운 위치로 이동시킨다. */
+    transform: scale(0.8) translate(-9px, 524px);
+  }
+  .hero figcaption .caption-chip {
+    transform: scale(0.8) translate(510px, 422px);
+  }
+  .hero figcaption .caption-storage {
+    transform: scale(0.8) translate(556px, 556px);
+  }
+  .hero h2 {
+    width: 515px;
+    height: 95px;
+  }
+}
+
+@media (max-width: 740px) {
+  .hero .inner {
+    padding-top: 40px;
+  }
+  .hero h1 {
+    margin: 0 auto 40px;
+    /* 모바일에서는 단순히 쌓이는 형태로 변경, 기본값은 static */
+    position: static;
+    transform: none;
+  }
+  .hero .figures {
+    height: auto;
+    margin-bottom: 100px;
+  }
+  .hero figure {
+    transform: none;
+  }
+  .hero figure img {
+    width: 337px;
+  }
+
+  /* 기존에 사용했던 이미지 대신 mobile 이미지로 변경 */
+  .hero figcaption .caption-camera {
+    width: 180px;
+    height: 37px;
+    background-image: url("../images/hero_ipad_caption_camera_mobile.png");
+    /* transform: scale(.8)인 상태에서 이미지 변경했으니 1로 다시 조정 */
+    transform: scale(1) translate(21px, 368px);
+  }
+  .hero figcaption .caption-chip {
+    transform: scale(0.8) translate(248px, 42px);
+  }
+  .hero figcaption .caption-storage {
+    transform: scale(0.8) translate(288px, 168px);
+  }
+  .hero h2 {
+    width: 295px;
+    height: 185px;
+    background-image: url("../images/hero_headline_mobile.png");
+  }
+  .hero p.pricing {
+    font-size: 20px;
+  }
+  .hero p.description {
+    /* 기존엔 width: 88%였으나, 모바일에서는 auto로 변경 */
+    width: auto;
+    font-size: 17px;
+  }
+}
+
+/* Power */
 .power {
   margin-top: 110px;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -1163,15 +1163,15 @@ main {
   .hero figure img {
     width: 540px;
   }
-  .hero figcaption .caption-camera {
+  .hero figure figcaption .caption-camera {
     /* scale을 사용하여 동일한 배수로 줄여야함. */
     /* translate를 통해 새로운 위치로 이동시킨다. */
     transform: scale(0.8) translate(-9px, 524px);
   }
-  .hero figcaption .caption-chip {
+  .hero figure figcaption .caption-chip {
     transform: scale(0.8) translate(510px, 422px);
   }
-  .hero figcaption .caption-storage {
+  .hero figure figcaption .caption-storage {
     transform: scale(0.8) translate(556px, 556px);
   }
   .hero h2 {
@@ -1202,17 +1202,17 @@ main {
   }
 
   /* 기존에 사용했던 이미지 대신 mobile 이미지로 변경 */
-  .hero figcaption .caption-camera {
+  .hero figure figcaption .caption-camera {
     width: 180px;
     height: 37px;
     background-image: url("../images/hero_ipad_caption_camera_mobile.png");
     /* transform: scale(.8)인 상태에서 이미지 변경했으니 1로 다시 조정 */
     transform: scale(1) translate(21px, 368px);
   }
-  .hero figcaption .caption-chip {
+  .hero figure figcaption .caption-chip {
     transform: scale(0.8) translate(248px, 42px);
   }
-  .hero figcaption .caption-storage {
+  .hero figure figcaption .caption-storage {
     transform: scale(0.8) translate(288px, 168px);
   }
   .hero h2 {


### PR DESCRIPTION
# Scale 함수
### scale(x,y) 크기(x축, y축)
### scale(.8) 배수로도 조절 가능하다.

```css
  /* 기존에 사용했던 이미지 대신 mobile 이미지로 변경 */
  .hero figure figcaption .caption-camera {
    width: 180px;
    height: 37px;
    background-image: url("../images/hero_ipad_caption_camera_mobile.png");
    /* transform: scale(.8)인 상태에서 이미지 변경했으니 1로 다시 조정 */
    transform: scale(1) translate(21px, 368px);
  }
  .hero figure figcaption .caption-chip {
    transform: scale(0.8) translate(248px, 42px);
  }
  .hero figure figcaption .caption-storage {
    transform: scale(0.8) translate(288px, 168px);
  }
```
